### PR TITLE
Add close button to course enrollment form

### DIFF
--- a/src/components/Courses.jsx
+++ b/src/components/Courses.jsx
@@ -355,6 +355,17 @@ const Courses = () => {
                       >
                         Proceed to Payment
                       </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setSelectedCourse(null);
+                          setShowForm(false);
+                          setFormErrors({});
+                        }}
+                        className="w-full bg-gray-600 text-white py-3 px-4 rounded-lg hover:bg-gray-700 transition-all font-semibold"
+                      >
+                        Close
+                      </button>
                     </form>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- add an extra button to close the course enrollment form

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68421fbc9260832b8dabfdff62e306db