### PR TITLE
Connect frontend to API and set up server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN npm ci --only=production
 
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/server.js ./
+COPY --from=builder /app/pages ./pages
+COPY --from=builder /app/lib ./lib
+COPY --from=builder /app/models ./models
 
 # Expose the port your app runs on
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -6,3 +6,15 @@ Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## Environment Variables
+
+The API layer requires a MongoDB connection string. Create a `.env` file with the
+following variable:
+
+```
+MONGODB_URI=<your mongodb connection uri>
+```
+
+When running the Docker image or the development server, ensure this variable is
+available so the API routes can connect to the database.

--- a/__tests__/apiHandlers.test.js
+++ b/__tests__/apiHandlers.test.js
@@ -1,0 +1,18 @@
+import enrollmentsHandler from '../pages/api/enrollments.js';
+
+function createRes() {
+  return {
+    statusCode: 0,
+    payload: null,
+    status(code) { this.statusCode = code; return this; },
+    json(data) { this.payload = data; return this; },
+  };
+}
+
+test('enrollments handler rejects non-POST', async () => {
+  const req = { method: 'GET' };
+  const res = createRes();
+  await enrollmentsHandler(req, res);
+  expect(res.statusCode).toBe(405);
+  expect(res.payload).toEqual({ success: false, message: 'Method not allowed' });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "node server.js"
   },
   "dependencies": {
     "axios": "^1.7.8",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,25 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import enrollmentsHandler from './pages/api/enrollments.js';
+import getEnrollmentsHandler from './pages/api/get-enrollments.js';
+
+const app = express();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+app.use(express.json());
+
+app.post('/api/enrollments', (req, res) => enrollmentsHandler(req, res));
+app.get('/api/get-enrollments', (req, res) => getEnrollmentsHandler(req, res));
+
+app.use(express.static(path.join(__dirname, 'dist')));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,1 @@
+// Jest setup file

--- a/src/components/Courses.jsx
+++ b/src/components/Courses.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Search, Clock, Book, Users, Star } from "lucide-react";
+import axios from "axios";
 
 // Importing SVG logos
 import AwsLogo from "../assets/aws-logo.svg"; 
@@ -129,12 +130,21 @@ const Courses = () => {
     return errors;
   };
 
-  const handleEnrollment = () => {
+  const handleEnrollment = async () => {
     const errors = validateForm();
     if (Object.keys(errors).length === 0) {
-      // Proceed with enrollment
-      console.log("Enrollment data:", formData);
-      // Add your enrollment logic here
+      try {
+        const response = await axios.post('/api/enrollments', {
+          name: formData.name,
+          email: formData.email,
+          phone: formData.phone,
+          courseType: selectedCourse.title,
+          amount: selectedCourse.price,
+        });
+        console.log('Enrollment stored:', response.data);
+      } catch (err) {
+        console.error('Enrollment failed:', err);
+      }
     } else {
       setFormErrors(errors);
     }


### PR DESCRIPTION
## Summary
- hook course enrollment form to the API
- add an Express-based server entry point
- include server code in Docker build
- document required MONGODB_URI env variable
- provide missing Jest setup file and new API test

## Testing
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68421e8ed41c832b87de1e1849314711