### PR TITLE
Add LGTM logo for observability course

### DIFF
--- a/src/assets/lgtm-logo.svg
+++ b/src/assets/lgtm-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 30">
+  <rect width="120" height="30" fill="#1f2937"/>
+  <text x="10" y="20" font-size="20" fill="white" font-family="Arial, Helvetica, sans-serif">LGTM</text>
+</svg>

--- a/src/components/Courses.jsx
+++ b/src/components/Courses.jsx
@@ -5,9 +5,10 @@ import { X, Search, Clock, Book, Users, Star } from "lucide-react";
 // Importing SVG logos
 import AwsLogo from "../assets/aws-logo.svg"; 
 import AzureLogo from "../assets/azure-logo.svg"; 
-import DevOpsLogo from "../assets/devops-logo.svg"; 
-import NextJsLogo from "../assets/next-js-logo.svg"; 
+import DevOpsLogo from "../assets/devops-logo.svg";
+import NextJsLogo from "../assets/next-js-logo.svg";
 import PythonLogo from "../assets/python-logo.svg";
+import LgtmLogo from "../assets/lgtm-logo.svg";
 
 const courses = [
   {
@@ -99,7 +100,25 @@ const courses = [
       "Working with Libraries: Exploring NumPy, Pandas, and Matplotlib for data analysis and visualization.",
       "Building Python Applications: Writing and deploying Python applications with best practices.",
     ],
-},
+  },
+  {
+    id: 6,
+    title: "obseverbility",
+    logo: LgtmLogo,
+    price: "£300",
+    duration: "6 weeks",
+    level: "Intermediate",
+    students: 0,
+    rating: 4.0,
+    category: "DevOps",
+    outline: [
+      "Introduction to Observability tools and principles.",
+      "Setting up logging, metrics, and tracing for applications.",
+      "Visualizing system health and performance metrics.",
+      "Alerting strategies and best practices.",
+      "Hands-on with popular observability platforms.",
+    ],
+  },
 
 ];
 


### PR DESCRIPTION
## Summary
- add LGTM logo asset
- use it for the obseverbility course

## Testing
- `npx jest --runInBand` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68421e8e9bcc832b9e72348f9320d1b3