### PR TITLE
Add Jest setup file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## Testing
+
+Jest is configured in `jest.config.js`. The `setupFilesAfterEnv` option points to
+`setupTests.js`, which currently loads React Testing Library helpers. Ensure
+you run `npm install` to fetch dev dependencies before running tests with
+`npx jest` or a similar command.

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,3 @@
+// Jest setup file for configuring the testing environment.
+// Currently imports utilities from React Testing Library.
+import '@testing-library/jest-dom/extend-expect';


### PR DESCRIPTION
## Summary
- add `setupTests.js` to configure Jest
- document how to run tests in README

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684220cf2c1c832b88980a1e481caed7