### PR TITLE
Add blog page and routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "mongoose": "^8.8.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.1",
         "stripe": "^17.4.0"
       },
       "devDependencies": {
@@ -2245,6 +2246,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -8914,6 +8924,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "mongoose": "^8.8.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.1",
     "stripe": "^17.4.0"
   },
   "devDependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,22 +1,17 @@
-import Navbar from "./components/Navbar";
-import HeroSection from "./components/HeroSection";
-import FeatureSection from "./components/FeatureSection";
-import Courses from "./components/Courses";
-import Footer from "./components/Footer";
-import Testimonials from "./components/Testimonials";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import Home from "./pages/Home";
+import Blog from "./pages/Blog";
+import EnrollmentsAdmin from "../pages/admin/enrollments.jsx";
 
 const App = () => {
   return (
-    <>
-      <Navbar />
-      <div className="max-w-7xl mx-auto pt-20 px-6">
-        <HeroSection />
-        <FeatureSection />
-        <Courses />
-        <Testimonials />
-        <Footer />
-      </div>
-    </>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/blog" element={<Blog />} />
+        <Route path="/admin/enrollments" element={<EnrollmentsAdmin />} />
+      </Routes>
+    </BrowserRouter>
   );
 };
 

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,5 +1,6 @@
 import { Menu, X, ChevronDown } from "lucide-react";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import logo from "../assets/logo.png";
 import { navItems } from "../constants"; // Ensure navItems reflect new sections
 import courses from "../data/courses";
@@ -7,6 +8,7 @@ import courses from "../data/courses";
 const Navbar = () => {
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
   const [showCourseDropdown, setShowCourseDropdown] = useState(false);
+  const navigate = useNavigate();
 
   const toggleNavbar = () => {
     setMobileDrawerOpen(!mobileDrawerOpen);
@@ -14,12 +16,16 @@ const Navbar = () => {
 
   const handleNavClick = (e, href) => {
     e.preventDefault();
-    const element = document.querySelector(href);
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth' });
-      setMobileDrawerOpen(false); // Close mobile menu after clicking
-      setShowCourseDropdown(false);
+    if (href.startsWith('#')) {
+      const element = document.querySelector(href);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+      }
+    } else {
+      navigate(href);
     }
+    setMobileDrawerOpen(false);
+    setShowCourseDropdown(false);
   };
 
   return (

--- a/src/constants/index.jsx
+++ b/src/constants/index.jsx
@@ -11,6 +11,7 @@ export const navItems = [
   { label: "Features", href: "#features" },
   { label: "Courses", href: "#courses" },
   { label: "Testimonials", href: "#testimonials" },
+  { label: "Blog", href: "/blog" },
 ];
 
 export const features = [

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,0 +1,17 @@
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+
+const Blog = () => {
+  return (
+    <>
+      <Navbar />
+      <div className="max-w-7xl mx-auto pt-20 px-6 min-h-screen text-white">
+        <h1 className="text-4xl font-bold mb-6">Blog</h1>
+        <p className="text-lg text-neutral-300">Coming soon! Check back for articles and updates.</p>
+      </div>
+      <Footer />
+    </>
+  );
+};
+
+export default Blog;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,23 @@
+import Navbar from "../components/Navbar";
+import HeroSection from "../components/HeroSection";
+import FeatureSection from "../components/FeatureSection";
+import Courses from "../components/Courses";
+import Footer from "../components/Footer";
+import Testimonials from "../components/Testimonials";
+
+const Home = () => {
+  return (
+    <>
+      <Navbar />
+      <div className="max-w-7xl mx-auto pt-20 px-6">
+        <HeroSection />
+        <FeatureSection />
+        <Courses />
+        <Testimonials />
+        <Footer />
+      </div>
+    </>
+  );
+};
+
+export default Home;


### PR DESCRIPTION
## Summary
- add React Router with routes for Home, Blog, and existing admin page
- create Blog and Home pages
- extend navigation menu with Blog item
- update navbar navigation logic

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68591abd92bc832bba8279878afc0d83