### PR TITLE
Fix blog menu link

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -21,6 +21,8 @@ const Navbar = () => {
       if (element) {
         element.scrollIntoView({ behavior: 'smooth' });
       }
+    } else if (href.startsWith('http')) {
+      window.location.href = href;
     } else {
       navigate(href);
     }

--- a/src/constants/index.jsx
+++ b/src/constants/index.jsx
@@ -11,7 +11,7 @@ export const navItems = [
   { label: "Features", href: "#features" },
   { label: "Courses", href: "#courses" },
   { label: "Testimonials", href: "#testimonials" },
-  { label: "Blog", href: "/blog" },
+  { label: "Blog", href: "https://tripplescale.substack.com" },
 ];
 
 export const features = [


### PR DESCRIPTION
## Summary
- open external blog homepage when clicking "Blog"
- use correct navItems href

## Testing
- `npm run lint` *(fails: 27 errors)*
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68591f5933a4832bbfa7f8d57843cf3e