### PR TITLE
Open blog link in new tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+coverage/

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -41,12 +41,15 @@ const Navbar = () => {
           <ul className="hidden lg:flex ml-14 space-x-12">
             {navItems.map((item, index) => (
               <li key={index}>
-                <a
-                  href={item.href}
-                  onClick={(e) => handleNavClick(e, item.href)}
-                >
-                  {item.label}
-                </a>
+                {item.newTab ? (
+                  <a href={item.href} target="_blank" rel="noopener noreferrer">
+                    {item.label}
+                  </a>
+                ) : (
+                  <a href={item.href} onClick={(e) => handleNavClick(e, item.href)}>
+                    {item.label}
+                  </a>
+                )}
               </li>
             ))}
             <li className="relative">
@@ -87,12 +90,15 @@ const Navbar = () => {
             <ul>
               {navItems.map((item, index) => (
                 <li key={index} className="py-4">
-                  <a 
-                    href={item.href}
-                    onClick={(e) => handleNavClick(e, item.href)}
-                  >
-                    {item.label}
-                  </a>
+                  {item.newTab ? (
+                    <a href={item.href} target="_blank" rel="noopener noreferrer">
+                      {item.label}
+                    </a>
+                  ) : (
+                    <a href={item.href} onClick={(e) => handleNavClick(e, item.href)}>
+                      {item.label}
+                    </a>
+                  )}
                 </li>
               ))}
             </ul>

--- a/src/constants/index.jsx
+++ b/src/constants/index.jsx
@@ -11,7 +11,7 @@ export const navItems = [
   { label: "Features", href: "#features" },
   { label: "Courses", href: "#courses" },
   { label: "Testimonials", href: "#testimonials" },
-  { label: "Blog", href: "https://tripplescale.substack.com" },
+  { label: "Blog", href: "https://tripplescale.substack.com", newTab: true },
 ];
 
 export const features = [


### PR DESCRIPTION
## Summary
- add a `newTab` property to the Blog nav item
- open external blog link in a new tab for desktop and mobile menus
- ignore coverage folder

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6859213c4f8c832b8524282ecb9a08c9